### PR TITLE
Popover and health bar bugs

### DIFF
--- a/docs/store.md
+++ b/docs/store.md
@@ -1,6 +1,6 @@
 ---
-title: Stat Bubbles
-description: Add Roll20 style stat bubbles to track HP and AC.
+title: Stat Bubbles for D&D
+description: Add health bars and armor class to your Owlbear Rodeo tokens
 author: Seamus Finlayson
 image: https://owlbear-rodeo-bubbles-extension.onrender.com/header.png
 icon: https://owlbear-rodeo-bubbles-extension.onrender.com/logo.png
@@ -12,7 +12,7 @@ learn-more: https://github.com/SeamusFinlayson/Bubbles-for-Owkbear-Rodeo
 
 # Stat Bubbles
 
-Add Roll20 style bubbles to track hit points, temporary hit points, and armor class.
+Add health bars and armor class to your Owlbear Rodeo tokens.
 
 ## How to use
 

--- a/docs/store.md
+++ b/docs/store.md
@@ -12,7 +12,7 @@ learn-more: https://github.com/SeamusFinlayson/Bubbles-for-Owkbear-Rodeo
 
 # Stat Bubbles
 
-Health Bars and Armor Class for your D&D adventures!
+Health Bars and Armor Class for your D&D adventures! Track hit points, maximum hit points, temporary hit points, armor class and hide the monsters stats from players.
 
 ## How to use
 
@@ -24,7 +24,7 @@ To add 6 to your HP type +6 and press Enter. To subtract 6 from your HP type -6 
 
 **Deigned to be keyboard friendly.**
 
-1. Click on a token and use the shortcut Shift + S to see and edit a token's trackers.
+1. Click on a token and use the shortcut Shift + S (or click the extension icon in the token's context menu) to see and edit a token's trackers.
 2. Press Tab to cycle through the bubbles.
 3. Press the Space key to toggle the switch.
 4. When you're done press Escape and the menu will close.
@@ -45,4 +45,4 @@ The hide switch:
 
 ## Support
 
-If you need support for this extension you can open an issue on [GitHub](https://github.com/SeamusFinlayson/Bubbles-for-Owkbear-Rodeo)
+If you need support for this extension you can open an issue on [GitHub](https://github.com/SeamusFinlayson/Bubbles-for-Owkbear-Rodeo) or message me in the Owlbear Rodeo discord @Seamus.

--- a/docs/store.md
+++ b/docs/store.md
@@ -1,6 +1,6 @@
 ---
 title: Stat Bubbles for D&D
-description: Add health bars and armor class to your Owlbear Rodeo tokens
+description: Health Bars and Armor Class for your D&D adventures!
 author: Seamus Finlayson
 image: https://owlbear-rodeo-bubbles-extension.onrender.com/header.png
 icon: https://owlbear-rodeo-bubbles-extension.onrender.com/logo.png
@@ -12,7 +12,7 @@ learn-more: https://github.com/SeamusFinlayson/Bubbles-for-Owkbear-Rodeo
 
 # Stat Bubbles
 
-Add health bars and armor class to your Owlbear Rodeo tokens.
+Health Bars and Armor Class for your D&D adventures!
 
 ## How to use
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,10 +1,10 @@
 {
-  "name": "Stat Bubbles",
+  "name": "Stat Bubbles for D&D",
   "version": "1.2.4",
   "manifest_version": 1,
   "author": "Seamus Finlayson",
   "homepage_url": "https://github.com/SeamusFinlayson/Bubbles-for-Owlbear-Rodeo",
   "icon": "/logo.png",
   "background_url": "/background.html",
-  "description": "Add Roll20 style stat bubbles to track HP and AC."
+  "description": "Add health bars and armor class to your Owlbear Rodeo tokens"
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Stat Bubbles",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "manifest_version": 1,
   "author": "Seamus Finlayson",
   "homepage_url": "https://github.com/SeamusFinlayson/Bubbles-for-Owlbear-Rodeo",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,5 +6,5 @@
   "homepage_url": "https://github.com/SeamusFinlayson/Bubbles-for-Owlbear-Rodeo",
   "icon": "/logo.png",
   "background_url": "/background.html",
-  "description": "Add health bars and armor class to your Owlbear Rodeo tokens"
+  "description": "Health Bars and Armor Class for your D&D adventures!"
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -52,7 +52,7 @@ OBR.onReady( async () => {
       OBR.popover.open({
         id: getPluginId("number-bubbles"),
         url: "/",
-        height: 50,
+        height: 54,
         width: 400,
         anchorElementId: elementId,
         //hidePaper: false,

--- a/src/background.ts
+++ b/src/background.ts
@@ -52,7 +52,7 @@ OBR.onReady( async () => {
       OBR.popover.open({
         id: getPluginId("number-bubbles"),
         url: "/",
-        height: 60,
+        height: 50,
         width: 400,
         anchorElementId: elementId,
         //hidePaper: false,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -124,8 +124,10 @@ const drawHealthBar = async (item: Image) => {
     
         //set color based on visibility
         var color = "darkgrey";
+        let setVisibilityProperty = item.visible;
         if (!visible) {
             color = "black";
+            setVisibilityProperty = false;
         }
 
         const backgroundShape = buildShape()
@@ -142,7 +144,8 @@ const drawHealthBar = async (item: Image) => {
         .layer("ATTACHMENT")
         .locked(true)
         .id(item.id + "health-background")
-        .visible(item.visible)
+        .visible(setVisibilityProperty)
+        .disableAttachmentBehavior(["ROTATION", "VISIBLE"])
         .build();
         
         var percentage = 0;
@@ -169,7 +172,8 @@ const drawHealthBar = async (item: Image) => {
         .layer("ATTACHMENT")
         .locked(true)
         .id(item.id + "health")
-        .visible(item.visible)
+        .visible(setVisibilityProperty)
+        .disableAttachmentBehavior(["ROTATION", "VISIBLE"])
         .build();
 
         const healthLabel = buildText()
@@ -183,13 +187,14 @@ const drawHealthBar = async (item: Image) => {
         .height(height + 0)
         .width(bounds.width)
         .fontWeight(400)
-        .visible(item.visible)
         //.strokeColor("black")
         //.strokeWidth(0)
         .attachedTo(item.id)
         .layer("TEXT")
         .locked(true)
         .id(item.id + "health-label")
+        .visible(setVisibilityProperty)
+        .disableAttachmentBehavior(["ROTATION", "VISIBLE"])
         .build();
 
         //add health bar to add array

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -125,9 +125,13 @@ const drawHealthBar = async (item: Image) => {
         //set color based on visibility
         var color = "darkgrey";
         let setVisibilityProperty = item.visible;
+        let backgroundOpacity = 0.7;
+        let healthOpacity = 0.5;
         if (!visible) {
             color = "black";
             setVisibilityProperty = false;
+            backgroundOpacity = 1;
+            healthOpacity = 0.8;
         }
 
         const backgroundShape = buildShape()
@@ -135,9 +139,9 @@ const drawHealthBar = async (item: Image) => {
         .height(height)
         .shapeType("RECTANGLE")
         .fillColor(color)
-        .fillOpacity(0.7)
+        .fillOpacity(backgroundOpacity)
         .strokeColor(color)
-        .strokeOpacity(0.5)
+        .strokeOpacity(0)
         .strokeWidth(0)
         .position({x: position.x, y: position.y})
         .attachedTo(item.id)
@@ -164,7 +168,7 @@ const drawHealthBar = async (item: Image) => {
         .height(height)
         .shapeType("RECTANGLE")
         .fillColor("red")
-        .fillOpacity(0.5)
+        .fillOpacity(healthOpacity)
         .strokeWidth(0)
         .strokeOpacity(0)
         .position({ x: position.x, y: position.y})
@@ -190,6 +194,7 @@ const drawHealthBar = async (item: Image) => {
         //.strokeColor("black")
         //.strokeWidth(0)
         .attachedTo(item.id)
+        .fillOpacity(1)
         .layer("TEXT")
         .locked(true)
         .id(item.id + "health-label")

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -99,12 +99,19 @@ const drawHealthBar = async (item: Image) => {
     try {
         visible = !metadata["hide"];
     } catch (error) {
-        visible = true;
+        if (!(error instanceof TypeError)) {
+            //console.log("type error")
+            throw {
+                error
+            }
+        } else {
+            visible = true;
+        }
     }
 
     const roll = await OBR.player.getRole();
     
-    if ((maxHealth > 0) && !(roll === "PLAYER" && !visible)) { //draw bar if it has max health and is visible
+    if ((maxHealth > 0) && !((roll === "PLAYER") && !visible)) { //draw bar if it has max health and is visible
 
         //get physical token properties
         const height = 26;
@@ -185,22 +192,11 @@ const drawHealthBar = async (item: Image) => {
         .id(item.id + "health-label")
         .build();
 
-        //should add these items to an array and add them in bulk
-
-        //only show player visible shapes
-        if (roll === "PLAYER" && visible) {
-            //await OBR.scene.local.deleteItems([item.id + "health-label"]);
-            //OBR.scene.local.addItems([backgroundShape, hpShape, healthLabel]);
-            addItemsArray.push(backgroundShape, hpShape, healthLabel);
-        } else if (roll === "GM" ) { //show gm all shapes
-            //await OBR.scene.local.deleteItems([item.id + "health-label"]);
-            //OBR.scene.local.addItems([backgroundShape, hpShape, healthLabel]);
-            addItemsArray.push(backgroundShape, hpShape, healthLabel);
-        }   
+        //add health bar to add array
+        addItemsArray.push(backgroundShape, hpShape, healthLabel);
         
     } else { // delete health bar
 
-        //await OBR.scene.local.deleteItems([item.id + "health-background", item.id + "health", item.id + "health-label"]);
         deleteItemsArray.push(item.id + "health-background", item.id + "health", item.id + "health-label");
     }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -36,17 +36,19 @@ async function startHealthBarUpdates() {
     
                 if(i > itemsLast.length - 1) { //check for extra items at the end of the list 
                     changedItems.push(items[i]);
-                }
-                else if( //check for notable changes in item values
-                    (itemsLast[i].position.x == items[i].position.x) &&
+                } else if( //check for scaling changes
+                    !((itemsLast[i].scale.x == items[i].scale.x) &&
+                    (itemsLast[i].scale.y == items[i].scale.y))
+                ) {
+                    deleteItemsArray.push(items[i].id + "health-label");
+                    changedItems.push(items[i]);
+                } else if( //check position and visibility changes
+                    !((itemsLast[i].position.x == items[i].position.x) &&
                     (itemsLast[i].position.y == items[i].position.y) &&
-                    (itemsLast[i].scale.x == items[i].scale.x) &&
-                    (itemsLast[i].scale.y == items[i].scale.y) &&
-                    (itemsLast[i].rotation == items[i].rotation) &&
+                    // (itemsLast[i].rotation == items[i].rotation) && //shouldn't need this check anymore because attachment rotation is disabled
                     (itemsLast[i].visible == items[i].visible) &&
-                    (JSON.stringify(itemsLast[i].metadata[getPluginId("metadata")]) == JSON.stringify(items[i].metadata[getPluginId("metadata")]))
-                ) {} //do nothing
-                else { //add changed items to change list
+                    (JSON.stringify(itemsLast[i].metadata[getPluginId("metadata")]) == JSON.stringify(items[i].metadata[getPluginId("metadata")])))
+                ) { //update items
                     changedItems.push(items[i]);
                 }
             }
@@ -59,12 +61,12 @@ async function startHealthBarUpdates() {
                 await drawHealthBar(item);
             }
             //console.log("Detected " + changedItems.length + " changes");
-    
-            //bulk add items 
-            OBR.scene.local.addItems(addItemsArray);
-    
+
             //bulk delete items
             OBR.scene.local.deleteItems(deleteItemsArray);
+
+            //bulk add items 
+            OBR.scene.local.addItems(addItemsArray);
     
             //clear add and delete arrays arrays
             addItemsArray.length = 0;
@@ -207,7 +209,7 @@ const drawHealthBar = async (item: Image) => {
         
     } else { // delete health bar
 
-        deleteItemsArray.push(item.id + "health-background", item.id + "health", item.id + "health-label");
+        await addItemAttachmentsToDeleteList(item);
     }
 
     return[];
@@ -302,4 +304,8 @@ export async function initScene() {
         refreshAllHealthBars();
         startHealthBarUpdates();
     }
+}
+
+async function addItemAttachmentsToDeleteList(item: Image) {
+    deleteItemsArray.push(item.id + "health-background", item.id + "health", item.id + "health-label");
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import OBR, { Image } from "@owlbear-rodeo/sdk";
 import { getPluginId } from "./getPluginId";
 import "./style.css";
+import popoverHTML from './popover.html?raw';
 
 /**
  * This file represents the HTML of the popover that is shown once
@@ -10,30 +11,7 @@ import "./style.css";
 OBR.onReady(async () => {
 
   // Setup the document
-  document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
-  <div class="center">
-
-    <label for="health" class="label">HP</label>
-    <input class="number-box dark" type="text" id="health" name="health">
-
-    <label for="max health" class="label">/</label>
-    <input class="number-box dark" type="text" id="max health" name="max health">
-
-    <label for="temporary health" class="label">Temp</label>
-    <input class="number-box dark" type="text" id="temporary health" name="temporary health"
-    style="border-color: lightgreen;">
-
-    <label for="armor class" class="label">AC</label>
-    <input class="number-box dark" type="text" id="armor class" 
-      name="armor class" style="border-color: lightblue;">
-
-    <label for="hide" class="label">Hide</label>
-    <label class="switch">
-      <input type="checkbox" id="hide">
-      <span class="slider round dark" id="slider span"></span>
-    </label>
-
-  </div>`;
+  document.querySelector<HTMLDivElement>("#app")!.innerHTML = popoverHTML;
 
   //OBR.theme.onChange( (theme) => {
     const theme = OBR.theme.getTheme()

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,7 +70,7 @@ OBR.onReady(async () => {
   } catch (error) {}
 
   //select health field by default
-  (document.getElementById(bubbles[0]) as HTMLInputElement)?.select()
+  (document.getElementById(bubbles[0]) as HTMLInputElement)?.select();
 
   // Attach on input listeners
   bubbles.forEach(

--- a/src/popover.html
+++ b/src/popover.html
@@ -1,0 +1,23 @@
+<div class="center">
+
+    <label for="health" class="label">HP</label>
+    <input class="number-box dark" type="text" id="health" name="health">
+
+    <label for="max health" class="label">/</label>
+    <input class="number-box dark" type="text" id="max health" name="max health">
+
+    <label for="temporary health" class="label">Temp</label>
+    <input class="number-box dark" type="text" id="temporary health" name="temporary health"
+    style="border-color: lightgreen;">
+
+    <label for="armor class" class="label">AC</label>
+    <input class="number-box dark" type="text" id="armor class" 
+      name="armor class" style="border-color: lightblue;">
+
+    <label for="hide" class="label">Hide</label>
+    <label class="switch">
+      <input type="checkbox" id="hide">
+      <span class="slider round dark" id="slider span"></span>
+    </label>
+
+</div>

--- a/src/style.css
+++ b/src/style.css
@@ -19,7 +19,7 @@ body {
   /* top: 50%;
   left: 50%;
   transform: translate(-50%, -50%); */
-  top: 5px;
+  top: 7px;
   left: 10px;
   right: 10px;
   /* padding: 10px; */

--- a/src/style.css
+++ b/src/style.css
@@ -15,11 +15,15 @@ body {
 }
 
 .center {
-  position: absolute;
-  top: 50%;
+  position:absolute;
+  /* top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%); */
+  top: 5px;
+  left: 10px;
+  /* padding: 10px; */
   white-space: nowrap;
+  /* overflow: scroll; */
 }
 
 .number-box {

--- a/src/style.css
+++ b/src/style.css
@@ -21,6 +21,7 @@ body {
   transform: translate(-50%, -50%); */
   top: 5px;
   left: 10px;
+  right: 10px;
   /* padding: 10px; */
   white-space: nowrap;
   /* overflow: scroll; */


### PR DESCRIPTION
- fixed ghost health bars appearing when tokens are rescaled
- fixed issue where on narrow displays parts of the popover would be inaccessible
- fixed bug where hidden bars would be visible to players when a monster token is dragged using the measure tool
- changed extension name (Stat Bubbles -> Stat Bubbles for D&D)
- changed extension description
- updated store page